### PR TITLE
Configurable authentication method and updated tests

### DIFF
--- a/config/gitlab.php
+++ b/config/gitlab.php
@@ -38,12 +38,14 @@ return [
     'connections' => [
 
         'main' => [
+            'auth_method' => 'http_token',
             'token' => 'your-token',
             'base_url' => 'http://git.yourdomain.com/api/v3/',
         ],
 
         'alternative' => [
-            'token' => 'your-token',
+            'auth_method' => 'oauth_token',
+            'token' => 'your-oauth-token',
             'base_url' => 'http://git.yourdomain.com/api/v3/',
         ],
 

--- a/src/GitLabFactory.php
+++ b/src/GitLabFactory.php
@@ -67,7 +67,7 @@ class GitLabFactory
     {
         $client = new Client($config['base_url']);
 
-        $client->authenticate($config['token'], 'http_token');
+        $client->authenticate($config['token'], empty($config['auth_method']) ? 'http_token' : $config['auth_method']);
 
         return $client;
     }

--- a/src/GitLabFactory.php
+++ b/src/GitLabFactory.php
@@ -45,7 +45,7 @@ class GitLabFactory
      */
     protected function getConfig(array $config)
     {
-        $keys = ['token', 'base_url'];
+        $keys = ['token', 'base_url', 'auth_method'];
 
         foreach ($keys as $key) {
             if (!array_key_exists($key, $config)) {
@@ -67,7 +67,7 @@ class GitLabFactory
     {
         $client = new Client($config['base_url']);
 
-        $client->authenticate($config['token'], empty($config['auth_method']) ? 'http_token' : $config['auth_method']);
+        $client->authenticate($config['token'], $config['auth_method']);
 
         return $client;
     }

--- a/tests/GitLabFactoryTest.php
+++ b/tests/GitLabFactoryTest.php
@@ -26,6 +26,7 @@ class GitLabFactoryTest extends AbstractTestCase
         $factory = $this->getGitLabFactory();
 
         $return = $factory->make([
+            'auth_method' => 'http_token',
             'token' => 'your-token',
             'base_url' => 'http://git.yourdomain.com/api/v3/',
         ]);
@@ -41,6 +42,7 @@ class GitLabFactoryTest extends AbstractTestCase
         $factory = $this->getGitLabFactory();
 
         $factory->make([
+            'auth_method' => 'http_token',
             'base_url' => 'http://git.yourdomain.com/api/v3/',
         ]);
     }
@@ -53,7 +55,32 @@ class GitLabFactoryTest extends AbstractTestCase
         $factory = $this->getGitLabFactory();
 
         $factory->make([
+            'auth_method' => 'http_token',
             'token' => 'your-token',
+        ]);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testMakeWithoutAuthMethod()
+    {
+        $factory = $this->getGitLabFactory();
+
+        $factory->make([
+            'token' => 'your-token',
+            'base_url' => 'http://git.yourdomain.com/api/v3/',
+        ]);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testMakeWithoutSettings()
+    {
+        $factory = $this->getGitLabFactory();
+
+        $factory->make([
         ]);
     }
 


### PR DESCRIPTION
This are the same changes as #2 but with updated tests.
This PR and #2 add support for configurable authentication methods. Gitlab allows the access via different tokens:
* private token
* oauth2 token

(see http://doc.gitlab.com/ce/api/)
So if your application uses private token you have to configure auth_method=http_token and for oauth2 you have to use oauth_token . (see https://github.com/m4tthumphrey/php-gitlab-api/blob/master/lib/Gitlab/Client.php#L45)
In my use-case the user authenticates via oauth2 at gitlab-server and this login process returns a oauth2 token and I have to use oauth_token as auth_method.

Closes #2 