### PR TITLE
Update README.md - publish vendor assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,10 @@ If you want you can use the [facade](http://laravel.com/docs/facades). Add the r
 
 ## Configuration
 
-Laravel GitLab requires connection configuration. To get started, you'll need to publish all vendor assets:
+Laravel GitLab requires connection configuration. To get started, you'll need to publish the Laravel GitLab vendor assets:
 
 ```bash
-php artisan vendor:publish
+php artisan vendor:publish --provider="Vinkla\GitLab\GitLabServiceProvider"
 ```
 
 This will create a `config/gitlab.php` file in your app that you can modify to set your configuration. Also, make sure you check for changes to the original config file in this package between releases.


### PR DESCRIPTION
Only publish Laravel GitLab's vendor assets, not all vendor assets.